### PR TITLE
restore compatibility with Django<2.0.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,8 @@ You can then enable the authentication classes for django rest framework by defa
         ...
         'DEFAULT_AUTHENTICATION_CLASSES': (
             ...
-            'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
+            # 'oauth2_provider.ext.rest_framework.OAuth2Authentication',  # django-oauth-toolkit < 1.0.0
+            'oauth2_provider.contrib.rest_framework.OAuth2Authentication',  # django-oauth-toolkit >= 1.0.0
             'rest_framework_social_oauth2.authentication.SocialAuthentication',
         ),
     }
@@ -194,7 +195,8 @@ To use Facebook as the authorization backend of your django-rest-framework api, 
         'DEFAULT_AUTHENTICATION_CLASSES': (
             ...
             # OAuth
-            'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
+            # 'oauth2_provider.ext.rest_framework.OAuth2Authentication',  # django-oauth-toolkit < 1.0.0
+            'oauth2_provider.contrib.rest_framework.OAuth2Authentication',  # django-oauth-toolkit >= 1.0.0
             'rest_framework_social_oauth2.authentication.SocialAuthentication',
         )
     }

--- a/rest_framework_social_oauth2/views.py
+++ b/rest_framework_social_oauth2/views.py
@@ -4,7 +4,10 @@ import json
 from braces.views import CsrfExemptMixin
 from oauthlib.oauth2.rfc6749.endpoints.token import TokenEndpoint
 from oauth2_provider.oauth2_backends import OAuthLibCore
-from oauth2_provider.contrib.rest_framework import OAuth2Authentication
+try:
+    from oauth2_provider.contrib.rest_framework import OAuth2Authentication
+except ImportError:
+    from oauth2_provider.ext.rest_framework import OAuth2Authentication
 from oauth2_provider.models import Application, AccessToken
 from oauth2_provider.settings import oauth2_settings
 from oauth2_provider.views.mixins import OAuthLibMixin

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     ],
     install_requires=[
         'djangorestframework>=3.0.1',
-        'django-oauth-toolkit>=1.0.0',
+        'django-oauth-toolkit>=0.9.0',
         'social-auth-app-django>=0.1.0',
         'django-braces>=1.11.0',
     ],


### PR DESCRIPTION
The requirements bump to `'django-oauth-toolkit>=1.0.0',` means that all new installations of this lib must be using django 2.x+

This PR adds a simple `try`/`except ImportError` in `views.py`, and updates the `README.rst` instructions.

