### PR TITLE
enabling json post requests to invalidate_sessions

### DIFF
--- a/rest_framework_social_oauth2/views.py
+++ b/rest_framework_social_oauth2/views.py
@@ -102,7 +102,7 @@ class RevokeTokenView(CsrfExemptMixin, OAuthLibMixin, APIView):
 @authentication_classes([OAuth2Authentication])
 @permission_classes([permissions.IsAuthenticated])
 def invalidate_sessions(request):
-    client_id = request.POST.get("client_id", None)
+    client_id = request.data.get("client_id", None)
     if client_id is None:
         return Response({
             "client_id": ["This field is required."]


### PR DESCRIPTION
**What happens right now:**
since the function invalidate_sessions looks in the POST body of the request for the client id, at the moment this endpoint only works when clients post to this endpoint with form-data --> content type `application/x-www-form-urlencoded ` or `multipart/form-data` 

**What should happen:**
the invalidate_sessions endpoint should also accept content-type` 'application/json'`.

Django Rest Framework's data field takes any type of content type in post requests and makes it accessible. 