### PR TITLE
Allow to convert authorization code to an access token.

### DIFF
--- a/rest_framework_social_oauth2/oauth2_grants.py
+++ b/rest_framework_social_oauth2/oauth2_grants.py
@@ -92,7 +92,7 @@ class SocialTokenGrant(RefreshTokenGrant):
                 request=request)
 
         try:
-            user = backend.do_auth(access_token=request.token)
+            user = backend.auth_complete(access_token=request.token)
         except requests.HTTPError as e:
             raise errors.InvalidRequestError(
                 description="Backend responded with HTTP{0}: {1}.".format(e.response.status_code,

--- a/rest_framework_social_oauth2/oauth2_grants.py
+++ b/rest_framework_social_oauth2/oauth2_grants.py
@@ -40,11 +40,12 @@ class SocialTokenGrant(RefreshTokenGrant):
         if request.grant_type != 'convert_token':
             raise errors.UnsupportedGrantTypeError(request=request)
 
-        # We check that a token parameter is present.
-        # It should contain the social token to be used with the backend
-        if request.token is None:
+        # We check that a either token or code parameter are present.
+        # It should contain the social token or authorization code
+        # to be used with the backend
+        if request.token is None and request.code is None:
             raise errors.InvalidRequestError(
-                description='Missing token parameter.',
+                description='Missing token and code parameter.',
                 request=request)
 
         # We check that a backend parameter is present.

--- a/rest_framework_social_oauth2/oauth2_grants.py
+++ b/rest_framework_social_oauth2/oauth2_grants.py
@@ -45,7 +45,7 @@ class SocialTokenGrant(RefreshTokenGrant):
         # to be used with the backend
         if request.token is None and request.code is None:
             raise errors.InvalidRequestError(
-                description='Missing token and code parameter.',
+                description='Missing token or code parameter.',
                 request=request)
 
         # We check that a backend parameter is present.


### PR DESCRIPTION
Regarding #72. This PR allows to send authorization code to convert token endpoint as described here: https://github.com/RealmTeam/django-rest-framework-social-oauth2/issues/72#issuecomment-274756958
In order for this to work I made a mixin that overrides `auth_complete` method of the backend. This solution is far from perfect. Mixin allows for only auth code flow, but it's a start. Minor adjustment can serve both convert access_token and auth code flows. https://gist.github.com/jkp85/1ed88aaafbb6ee10f31b8452a552bfef