### PR TITLE
Set Django request object through a server method call

### DIFF
--- a/rest_framework_social_oauth2/oauth2_backends.py
+++ b/rest_framework_social_oauth2/oauth2_backends.py
@@ -5,14 +5,33 @@ from __future__ import unicode_literals
 from oauth2_provider.oauth2_backends import OAuthLibCore
 from oauth2_provider.settings import oauth2_settings
 
+from .oauth2_endpoints import SocialTokenServer
+
 
 class KeepRequestCore(oauth2_settings.OAUTH2_BACKEND_CLASS):
     """
-    Subclass of OAuthLibCore used only for the sake of keeping the django
-    request object by placing it in the headers.
-    This is a hack and we need a better solution for this.
+    Subclass of `oauth2_settings.OAUTH2_BACKEND_CLASS`, used for the sake of
+    keeping the Django request object by passing it through to the
+    `server_class` instance.
+
+    This backend should only be used in views with SocialTokenServer
+    as the `server_class`.
     """
-    def _extract_params(self, request):
-        uri, http_method, body, headers = super(KeepRequestCore, self)._extract_params(request)
-        headers["Django-request-object"] = request
-        return uri, http_method, body, headers
+
+    def __init__(self, *args, **kwargs):
+        super(KeepRequestCore, self).__init__(*args, **kwargs)
+        if not isinstance(self.server, SocialTokenServer):
+            raise TypeError(
+                "server_class must be an instance of 'SocialTokenServer'"
+            )
+
+    def create_token_response(self, request):
+        """
+        A wrapper method that calls create_token_response on `server_class` instance.
+        This method is modified to also pass the `django.http.HttpRequest`
+        request object.
+
+        :param request: The current django.http.HttpRequest object
+        """
+        self.server.set_request_object(request)
+        return super(KeepRequestCore, self).create_token_response(request)


### PR DESCRIPTION
Slight improvement to the way Django request object was handled previously.
This will simply let the backend set the request object to the server class instance, and have it consumed inside the server class.

This solves the issue with:
* Dubious use of headers
* Use of `_`-prefixed method from an internal library

This doesn't solve the issue of:
* Passing duplicate data, as `uri, http_method, body, headers` are still passed along with the request