### PR TITLE
Django 3 compatible

### DIFF
--- a/rest_framework_social_oauth2/views.py
+++ b/rest_framework_social_oauth2/views.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 import json
 
-from braces.views import CsrfExemptMixin
 from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
 from oauthlib.oauth2.rfc6749.endpoints.token import TokenEndpoint
 from social_core.exceptions import MissingBackend
 from social_django.utils import load_strategy, load_backend
@@ -23,6 +24,18 @@ from rest_framework.views import APIView
 
 from .oauth2_backends import KeepRequestCore
 from .oauth2_endpoints import SocialTokenServer
+
+
+class CsrfExemptMixin(object):
+    """
+    Exempts the view from CSRF requirements.
+    NOTE:
+        This should be the left-most mixin of a view.
+    """
+
+    @method_decorator(csrf_exempt)
+    def dispatch(self, *args, **kwargs):
+        return super(CsrfExemptMixin, self).dispatch(*args, **kwargs)
 
 
 class TokenView(CsrfExemptMixin, OAuthLibMixin, APIView):

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
         'djangorestframework>=3.0.1',
         'django-oauth-toolkit>=0.9.0',
         'social-auth-app-django>=0.1.0',
-        'django-braces>=1.11.0',
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Removing six from dependencies (removing django-braces that depends on six) to make it work with django v3 (release coming on this december)

Also I think this is now python3 compatible.

I just copied only the relevant method from django-braces into here. We don't need the extra things from django-braces, and one less dependency here is better.