### PR TITLE
Drop Python 2 and Python < 3.5, update dependencies

### DIFF
--- a/rest_framework_social_oauth2/authentication.py
+++ b/rest_framework_social_oauth2/authentication.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 try:
     from django.urls import reverse
 except ImportError:  # Will be removed in Django 2.0

--- a/rest_framework_social_oauth2/backends.py
+++ b/rest_framework_social_oauth2/backends.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 try:
     from django.urls import reverse
 except ImportError:  # Will be removed in Django 2.0

--- a/rest_framework_social_oauth2/management/commands/createapp.py
+++ b/rest_framework_social_oauth2/management/commands/createapp.py
@@ -1,6 +1,6 @@
+from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand, CommandError
 from oauth2_provider.models import Application
-from django.contrib.auth.models import User
 from oauth2_provider.generators import generate_client_id, generate_client_secret
 
 

--- a/rest_framework_social_oauth2/oauth2_backends.py
+++ b/rest_framework_social_oauth2/oauth2_backends.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import unicode_literals
-
 from oauth2_provider.oauth2_backends import OAuthLibCore
 from oauth2_provider.settings import oauth2_settings
 

--- a/rest_framework_social_oauth2/oauth2_endpoints.py
+++ b/rest_framework_social_oauth2/oauth2_endpoints.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import unicode_literals
-
 import logging
 
 from django.http import HttpRequest

--- a/rest_framework_social_oauth2/oauth2_grants.py
+++ b/rest_framework_social_oauth2/oauth2_grants.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import unicode_literals
-
 import logging
 
 try:

--- a/rest_framework_social_oauth2/settings.py
+++ b/rest_framework_social_oauth2/settings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from django.conf import settings
 
 DRFSO2_PROPRIETARY_BACKEND_NAME = getattr(settings, 'DRFSO2_PROPRIETARY_BACKEND_NAME', "Django")

--- a/rest_framework_social_oauth2/urls.py
+++ b/rest_framework_social_oauth2/urls.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from django.conf.urls import url, include
 from oauth2_provider.views import AuthorizationView
 

--- a/rest_framework_social_oauth2/views.py
+++ b/rest_framework_social_oauth2/views.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 
 from braces.views import CsrfExemptMixin
@@ -8,10 +7,7 @@ from social_core.exceptions import MissingBackend
 from social_django.utils import load_strategy, load_backend
 from social_django.views import NAMESPACE
 
-try:
-    from oauth2_provider.contrib.rest_framework import OAuth2Authentication
-except ImportError:
-    from oauth2_provider.ext.rest_framework import OAuth2Authentication
+from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 from oauth2_provider.models import Application, AccessToken
 from oauth2_provider.settings import oauth2_settings
 from oauth2_provider.views.mixins import OAuthLibMixin

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,8 @@
 from setuptools import setup, find_packages
+import sys
+
+if sys.version_info < (3, 5):
+    raise SystemError("This package is for Python 3.5 and above.")
 
 setup(
     name='django-rest-framework-social-oauth2',
@@ -15,7 +19,6 @@ setup(
         "Environment :: Web Environment",
         "Framework :: Django",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,9 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     install_requires=[
-        'djangorestframework>=3.0.1',
-        'django-oauth-toolkit>=0.9.0',
-        'social-auth-app-django>=0.1.0',
+        'djangorestframework>=3.10.3',
+        'django-oauth-toolkit>=0.12.0',
+        'social-auth-app-django>=3.1.0',
         'django-braces>=1.11.0',
     ],
     include_package_data=True,


### PR DESCRIPTION
I think it's time this moves along with the rest of frameworks (DRF, social-auth-django) and drops Python 2 support. Also added checking compatibility in `setup.py`.
Dependency update is long overdue, as well.