### PR TITLE
fixed the url to re_path due to deprecation

### DIFF
--- a/rest_framework_social_oauth2/urls.py
+++ b/rest_framework_social_oauth2/urls.py
@@ -1,16 +1,17 @@
-from django.conf.urls import url, include
+from django.conf.urls import include
+from django.urls import re_path
 from oauth2_provider.views import AuthorizationView
 
-from .views import ConvertTokenView, TokenView, RevokeTokenView, invalidate_sessions, DisconnectBackendView
-
-app_name = 'drfso2'
+from .views import ConvertTokenView, TokenView, RevokeTokenView, invalidate_sessions
 
 urlpatterns = [
-    url(r'^authorize/?$', AuthorizationView.as_view(), name="authorize"),
-    url(r'^token/?$', TokenView.as_view(), name="token"),
-    url('', include('social_django.urls', namespace="social")),
-    url(r'^convert-token/?$', ConvertTokenView.as_view(), name="convert_token"),
-    url(r'^revoke-token/?$', RevokeTokenView.as_view(), name="revoke_token"),
-    url(r'^invalidate-sessions/?$', invalidate_sessions, name="invalidate_sessions"),
-    url(r'^disconnect-backend/?$', DisconnectBackendView.as_view(), name="disconnect_backend")
+    re_path(r'^authorize/?$', AuthorizationView.as_view(), name="authorize"),
+    re_path(r'^token/?$', TokenView.as_view(), name="token"),
+    re_path('', include('social_django.urls', namespace="social")),
+    re_path(r'^convert-token/?$', ConvertTokenView.as_view(), name="convert_token"),
+    re_path(r'^revoke-token/?$', RevokeTokenView.as_view(), name="revoke_token"),
+    re_path(r'^invalidate-sessions/?$', invalidate_sessions, name="invalidate_sessions")
 ]
+
+
+

--- a/rest_framework_social_oauth2/urls.py
+++ b/rest_framework_social_oauth2/urls.py
@@ -1,8 +1,10 @@
 from django.conf.urls import include
-from django.urls import re_path
 from oauth2_provider.views import AuthorizationView
+from django.urls import re_path
 
-from .views import ConvertTokenView, TokenView, RevokeTokenView, invalidate_sessions
+from .views import ConvertTokenView, TokenView, RevokeTokenView, invalidate_sessions, DisconnectBackendView
+
+app_name = 'drfso2'
 
 urlpatterns = [
     re_path(r'^authorize/?$', AuthorizationView.as_view(), name="authorize"),
@@ -10,8 +12,10 @@ urlpatterns = [
     re_path('', include('social_django.urls', namespace="social")),
     re_path(r'^convert-token/?$', ConvertTokenView.as_view(), name="convert_token"),
     re_path(r'^revoke-token/?$', RevokeTokenView.as_view(), name="revoke_token"),
-    re_path(r'^invalidate-sessions/?$', invalidate_sessions, name="invalidate_sessions")
+    re_path(r'^invalidate-sessions/?$', invalidate_sessions, name="invalidate_sessions"),
+    re_path(r'^disconnect-backend/?$', DisconnectBackendView.as_view(), name="disconnect_backend")
 ]
+
 
 
 


### PR DESCRIPTION
the use of keyword url when declaring url pattern has been deprecated in django 4 and instead replaced with re_path which supports regex in django 4