### PR TITLE
Change django urls import path in case of ImportError

### DIFF
--- a/rest_framework_social_oauth2/urls.py
+++ b/rest_framework_social_oauth2/urls.py
@@ -1,4 +1,8 @@
-from django.conf.urls import url, include
+try:
+    from django.conf.urls import url, include
+except ImportError:
+    from django.urls import include
+    from django.urls import re_path as url
 from oauth2_provider.views import AuthorizationView
 
 from .views import ConvertTokenView, TokenView, RevokeTokenView, invalidate_sessions, DisconnectBackendView


### PR DESCRIPTION
Ideally we should decide which module to import based on the Django version, but this is a stop-gap solution to get things running for Django 4 onwards.