### PR TITLE
Fixbug Fixing "urls" to support Django 4, older versions Fixes #254

### DIFF
--- a/rest_framework_social_oauth2/urls.py
+++ b/rest_framework_social_oauth2/urls.py
@@ -1,4 +1,9 @@
-from django.conf.urls import url, include
+from django.conf.urls import include
+try:
+    from django.conf.urls import url
+except ImportError:
+    from django.urls import re_path as url
+
 from oauth2_provider.views import AuthorizationView
 
 from .views import ConvertTokenView, TokenView, RevokeTokenView, invalidate_sessions, DisconnectBackendView


### PR DESCRIPTION
This helps with Django4.0 and would also work with the older version.

Replace
```python
from django.conf.urls import url, include
```
To
```python
from django.conf.urls import include
try:
    from django.conf.urls import url
except ImportError:
    from django.urls import re_path as url
```